### PR TITLE
[codex] Handle sync timeout in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ wavespeed config [--default-model …]     View / update CLI defaults
 
 # generation
 wavespeed run [model|alias] -p "…"       Run any model or alias (uses defaultModel if omitted)
+wavespeed run <model|alias> --sync       Attempt sync wait; timed-out tasks remain queryable
 wavespeed run <model|alias> -h           Dynamic schema-based help (alias-aware)
 wavespeed schema <model>                 Pretty-print a model's input schema
 wavespeed models [query]                 Browse the live catalog (cached 1h)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wavespeed/cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wavespeed/cli",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wavespeed/cli",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wavespeed/cli",
-      "version": "0.1.0",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavespeed/cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "WaveSpeed CLI — one command to run any WaveSpeed AI model from your terminal.",
   "publishConfig": {
     "access": "public"

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -19,6 +19,29 @@ function extractUrls(output: any): string[] {
   return [];
 }
 
+type SyncTimeoutDetails = {
+  predictionId?: string;
+  resultUrl?: string;
+};
+
+function cleanTrailingPunctuation(value: string): string {
+  return value.replace(/[).,]+$/, '');
+}
+
+function extractSyncTimeoutDetails(message: string): SyncTimeoutDetails | null {
+  if (!message.includes('Sync mode timed out')) return null;
+
+  const taskIdMatch =
+    message.match(/task_id:\s*([^)]+)/) ??
+    message.match(/Prediction ID:\s*([^\s.]+)/);
+  const resultUrlMatch = message.match(/Query the result later at:\s*(\S+)/);
+
+  return {
+    predictionId: taskIdMatch?.[1] ? cleanTrailingPunctuation(taskIdMatch[1]) : undefined,
+    resultUrl: resultUrlMatch?.[1] ? cleanTrailingPunctuation(resultUrlMatch[1]) : undefined,
+  };
+}
+
 function failMissingModel(): never {
   const msg =
     'No model specified. Pass a model ID as the first argument, ' +
@@ -51,7 +74,7 @@ export function registerRun(program: Command): void {
     .option('-p, --prompt <text>', 'Shorthand for --input prompt=<text>')
     .option('--input-file <path>', 'JSON file with full input object')
     .option('--download [path]', 'Save outputs locally (optional path template, e.g. "./out/{index}.{ext}")')
-    .option('--sync', 'Use synchronous mode (single request, no polling)')
+    .option('--sync', 'Attempt sync mode; timed-out tasks can still be queried later')
     .option('--json', 'Emit a single JSON object on stdout (progress goes to stderr)')
     .option('--output-dir <dir>', 'Directory for --download when no path is given')
     .action(async (modelArg: string | undefined, opts: any) => {
@@ -101,8 +124,38 @@ export function registerRun(program: Command): void {
         }
         spinner.succeed(`Done in ${Math.floor((Date.now() - startedAt) / 1000)}s.`);
       } catch (err: any) {
-        spinner.fail(err.message ?? String(err));
-        if (isJsonMode()) emitJsonError(err.message ?? String(err));
+        const message = err.message ?? String(err);
+        const syncTimeout = opts.sync ? extractSyncTimeoutDetails(message) : null;
+
+        if (syncTimeout && !isJsonMode()) {
+          spinner.fail('Sync mode timed out; the task is still processing asynchronously.');
+          log(chalk.gray('  reason: ') + message);
+          if (syncTimeout.predictionId) {
+            log(chalk.gray('  prediction: ') + chalk.white(syncTimeout.predictionId));
+            log(chalk.gray('  query:      ') + chalk.cyan(`wavespeed show ${syncTimeout.predictionId}`));
+          }
+          if (syncTimeout.resultUrl) {
+            log(chalk.gray('  result URL: ') + chalk.cyan(syncTimeout.resultUrl));
+          }
+        } else {
+          spinner.fail(message);
+        }
+
+        if (isJsonMode()) {
+          emitJsonError(
+            message,
+            syncTimeout
+              ? {
+                  sync_timeout: true,
+                  prediction_id: syncTimeout.predictionId,
+                  result_url: syncTimeout.resultUrl,
+                  query_command: syncTimeout.predictionId
+                    ? `wavespeed show ${syncTimeout.predictionId}`
+                    : undefined,
+                }
+              : {},
+          );
+        }
         process.exit(1);
       }
 


### PR DESCRIPTION
## What changed
- Detect sync-mode timeout errors from the SDK/API in `wavespeed run --sync`.
- Show a clear message that the task is still processing asynchronously.
- Include the prediction ID, result URL, and `wavespeed show <id>` query command in human output when available.
- Include `sync_timeout`, `prediction_id`, `result_url`, and `query_command` in `--json` error output.
- Update README command help and align the lockfile package version with `package.json`.

## Why
The API no longer converts sync timeout into an async success response. A sync timeout means the task was submitted and is still queryable, so CLI users need an actionable error instead of a generic failure.

## User impact
Successful `run()` output remains unchanged. On sync timeout, the command exits non-zero but gives users the prediction ID and query path.

## Validation
- `npm run lint`
- `npm run build`
- `npm run test:smoke`
- `git diff --check`